### PR TITLE
load-starter: Support Grafana dashboards

### DIFF
--- a/load-starter/load-starter.go
+++ b/load-starter/load-starter.go
@@ -318,8 +318,9 @@ func writeSlackMessage(startTime time.Time, endTime time.Time, config Config) {
 	var testObj map[string]interface{}
 
 	log.Info().Msg("Validating the message...")
-	// This will check that the rendered message is actually a valid YAML, and e.g. that there are no tabs in it, among other things
 	log.Debug().Msgf("Raw message:\n%s", rawMessage)
+	// This will check that the rendered message is actually a valid YAML, and e.g. that there are no tabs in it, among other things
+
 	err := yaml.Unmarshal([]byte(rawMessage), &testObj)
 	check(err)
 


### PR DESCRIPTION
Generally, not a big fan of the fact that we're building dashboards links inside `load-starter`. We should perhaps move the links handling logic into a separate helper script.