### PR TITLE
Add configuration builtin for pausing (sleeping) for a defined duration to `load-starter` [QE-4]

### DIFF
--- a/load-starter/action-run-external.go
+++ b/load-starter/action-run-external.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Action that allows to run external commands
+// RunExternalAction that allows to run external commands
 type RunExternalAction struct {
 	cmd []string
 }

--- a/load-starter/examples/simple_vegeta.py
+++ b/load-starter/examples/simple_vegeta.py
@@ -2,6 +2,7 @@ CONFIG_VERSION = "1.0.0"
 VEGETA_URL = "http://localhost:7770"
 
 def add_vegeta_tests():
+    add_sleep("10s")
     add_vegeta_test(
         duration=duration("30s"),
         test_type="session",
@@ -23,6 +24,8 @@ def add_vegeta_tests():
         },
 
     )
+    add_sleep(duration("20s"))
+
 
 # setup some vegeta tests
 set_load_tester_url(VEGETA_URL)

--- a/load-starter/locust.go
+++ b/load-starter/locust.go
@@ -26,6 +26,7 @@ type LocustTestAction struct {
 	LoadTesterUrl string
 }
 
+// CreateLocustTestAction creates a TestConfig for a Locust attack
 func CreateLocustTestAction(duration time.Duration, name string, description string, loadTesterUrl string, users int64, spawnRate int64) LocustTestAction {
 	loadTesterUrl = strings.TrimSuffix(loadTesterUrl, "/")
 

--- a/load-starter/sleep-action.go
+++ b/load-starter/sleep-action.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"time"
+)
+
+// SleepAction pauses the attack for the specified amount of time
+type SleepAction struct {
+	duration time.Duration
+}
+
+func (action SleepAction) GetDuration() time.Duration {
+	return action.duration
+}
+
+func (action SleepAction) GetName() string {
+	return fmt.Sprintf("sleep(%s)", action.duration)
+}
+
+func (action SleepAction) GetTestInfo() *TestInfo {
+	return nil
+}
+
+func (action SleepAction) Run() error {
+	var err error
+
+	if Params.dryRun {
+		log.Info().Msgf("[dry-run] Not running would sleep for: `%s`", action.duration)
+	} else {
+		log.Info().Msgf("Sleeping for %s", action.duration)
+		time.Sleep(action.duration)
+	}
+
+	return err
+}

--- a/load-starter/starlark-integration.go
+++ b/load-starter/starlark-integration.go
@@ -26,6 +26,7 @@ func LoadStarlarkConfig(configPath string) (Config, error) {
 		"add_locust_test":     starlark.NewBuiltin("add_locust_test", tests.addLocustTestBuiltin),
 		"add_vegeta_test":     starlark.NewBuiltin("add_vegeta_test", tests.addVegetaTestBuiltin),
 		"add_run_external":    starlark.NewBuiltin("add_run_external", tests.addRunExternalBuiltin),
+		"add_sleep":           starlark.NewBuiltin("add_sleep", tests.addSleepBuiltin),
 		"Nanosecond":          StarlarkDuration{val: time.Nanosecond, frozen: true},
 		"Microsecond":         StarlarkDuration{val: time.Microsecond, frozen: true},
 		"Millisecond":         StarlarkDuration{val: time.Millisecond, frozen: true},
@@ -528,6 +529,27 @@ func (env *LoadTestEnv) addRunExternalBuiltin(thread *starlark.Thread, b *starla
 	}
 
 	env.LoadTestActions = append(env.LoadTestActions, RunExternalAction{cmd: processedCmd})
+
+	return
+}
+
+// addSleepBuiltin implements the builtin add_sleep(duration:str|duration)
+func (env *LoadTestEnv) addSleepBuiltin(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (retVal starlark.Value, err error) {
+	var duration starlark.Value
+
+	retVal = starlark.None
+
+	if err = starlark.UnpackArgs(b.Name(), args, kwargs, "duration", &duration); err != nil {
+		return
+	}
+
+	var durationVal time.Duration
+	durationVal, err = toDuration(duration)
+	if err != nil {
+		return
+	}
+
+	env.LoadTestActions = append(env.LoadTestActions, SleepAction{duration: durationVal})
 
 	return
 }


### PR DESCRIPTION
Adds ability to pause for a specified amount of time between attacks