### PR TITLE
feat(influxdb-monitor): Allow to specify measurement filters

### DIFF
--- a/influxdb-monitor/influxdb-monitor.go
+++ b/influxdb-monitor/influxdb-monitor.go
@@ -4,21 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-func getKafkaLagQuery(bucketName string, measurement string) string {
-	return fmt.Sprintf(`
-from(bucket: "%s")
-  |> range(start: -1m)
-  |> filter(fn: (r) => r["_measurement"] == "%s")
-  |> last()`,
-		bucketName, measurement)
-}
 
 type ErrorType int
 
@@ -29,11 +21,51 @@ const (
 	NoData
 	Stuck
 	UnexpectedNilValue
+	BadFilter
 )
+
+type CliParams struct {
+	influxDbServer *string
+	influxDbToken  *string
+	organisationId *string
+	dryRun         bool
+	bucketName     *string
+	measurement    *string
+	filters        *[]string
+}
+
+var Params CliParams
+
+func getKafkaLagQuery(bucketName string, measurement string, filters []string) string {
+	// Prepare filters
+	formatted_entries := []string{}
+	for _, filter := range filters {
+		elements := strings.Split(filter, "=")
+		if len(elements) != 2 {
+			ExitWithError(BadFilter, filter)
+		}
+		name := elements[0]
+		value := elements[1]
+		formatted_entries = append(formatted_entries, fmt.Sprintf("  |> filter(fn: (r) => r[\"%s\"] == \"%s\")", name, value))
+	}
+	filtering_entries := strings.Join(formatted_entries, "\n")
+	if len(filtering_entries) > 0 {
+		filtering_entries = "\n" + filtering_entries
+	}
+
+	// Prepare the query
+	query := fmt.Sprintf(`
+from(bucket: "%s")
+  |> range(start: -1m)
+  |> filter(fn: (r) => r["_measurement"] == "%s")%s
+  |> last()`,
+		bucketName, measurement, filtering_entries)
+
+	return query
+}
 
 func QueryInfluxDb() {
 	fmt.Printf("Using InfluxDB URL: %s\n", *Params.influxDbServer)
-	fmt.Printf("Waiting for measurement '%s' to drop to 0...\n", *Params.measurement)
 
 	// Create a new client using an InfluxDB server base URL and an authentication token
 	client := influxdb2.NewClient(*Params.influxDbServer, *Params.influxDbToken)
@@ -42,7 +74,10 @@ func QueryInfluxDb() {
 	// Get query client
 	queryAPI := client.QueryAPI(*Params.organisationId)
 	// get QueryTableResult
-	query := getKafkaLagQuery(*Params.bucketName, *Params.measurement)
+	query := getKafkaLagQuery(*Params.bucketName, *Params.measurement, *Params.filters)
+	fmt.Printf("InfluxDB query:\n%s\n\n", query)
+
+	fmt.Printf("Waiting for measurement '%s' to drop to 0...\n", *Params.measurement)
 	const waitTime = 30 * time.Second
 	var dataValue, previousDataValue float64
 	var sameQueueSizeCounter int
@@ -115,21 +150,12 @@ func ExitWithError(errorCode ErrorType, aux interface{}) {
 		msg = "\nNo data found at iteration: %d"
 	case UnexpectedNilValue:
 		msg = "\nNil data found at iteration: %d"
+	case BadFilter:
+		msg = "\nInvalid filter specified: %s\n"
 	}
 	_, _ = fmt.Fprintf(os.Stderr, msg, aux)
 	os.Exit(int(errorCode))
 }
-
-type CliParams struct {
-	influxDbServer *string
-	influxDbToken  *string
-	organisationId *string
-	dryRun         bool
-	bucketName     *string
-	measurement    *string
-}
-
-var Params CliParams
 
 func ShowParams() {
 
@@ -140,8 +166,9 @@ Cli parameters:
     orgId: %v
     bucketName: %s
     measurement: %s
+    filters: %v
     dryRun: %t`,
-		*Params.influxDbServer, *Params.influxDbToken, *Params.organisationId, *Params.bucketName, *Params.measurement, Params.dryRun)
+		*Params.influxDbServer, *Params.influxDbToken, *Params.organisationId, *Params.bucketName, *Params.measurement, *Params.filters, Params.dryRun)
 
 	fmt.Printf(`
 
@@ -186,6 +213,7 @@ func cliSetup() *cobra.Command {
 	Params.organisationId = rootCmd.Flags().StringP("organisation", "o", "", "InfluxDB organisation id")
 	Params.bucketName = rootCmd.Flags().StringP("bucket-name", "b", "statsd", "Bucket where the metric is stored")
 	Params.measurement = rootCmd.Flags().StringP("measurement", "m", "kafka_consumer_lag", "Name of the measurement (metric)")
+	Params.filters = rootCmd.Flags().StringSliceP("filter", "f", []string{}, "Measurement filters")
 	rootCmd.Flags().BoolVarP(&Params.dryRun, "dry-run", "", false, "dry-run mode")
 
 	flags := rootCmd.Flags()
@@ -194,7 +222,6 @@ func cliSetup() *cobra.Command {
 	viper.BindPFlag("influxdb-url", flags.Lookup("influxdb-url"))
 
 	return rootCmd
-
 }
 
 func main() {


### PR DESCRIPTION
This will help to write more specific filters, e.g. for different Kafka consumer groups.