### PR TITLE
feat(stats-collector): Add metrics metadata

### DIFF
--- a/stats-collector/influx_stats_dynamic.py
+++ b/stats-collector/influx_stats_dynamic.py
@@ -1,15 +1,13 @@
 import logging
 import yaml
 from datetime import datetime
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict, Union, Any
 from dataclasses import dataclass
 
 from influxdb_client import InfluxDBClient
 
-
 from report import Report, MetricSummary, MetricValue
 from util import get_scalar_from_result, to_flux_datetime
-
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +18,7 @@ class MetricQueryArgs:
     filters: Dict[str, str]
 
     @staticmethod
-    def from_dict(d: dict) -> "MetricQuery":
+    def from_dict(d: dict) -> "MetricQueryArgs":
         assert type(d) is dict
 
         quantiles = d.get("quantiles", [])
@@ -94,7 +92,8 @@ class MetricQuery:
 
 @dataclass
 class DynamicQueryProfile:
-    metrics = Dict[str, MetricQuery]
+    metrics: Dict[str, MetricQuery]
+    metadata: Dict[str, Any]  # kept as an opaque dict since we only pass it along to the report
 
     @staticmethod
     def load(path: str) -> "DynamicQueryProfile":
@@ -111,16 +110,14 @@ class DynamicQueryProfile:
         Load the profile from the given string
         """
         raw = yaml.safe_load(s)
-        res = DynamicQueryProfile()
         metrics_dict = {}
+        res = DynamicQueryProfile(metrics=metrics_dict, metadata=raw.get("_meta", None))
 
         metrics_raw = raw.get("metrics", {})
         assert type(metrics_raw) is dict
 
         for metric_key, metric_dict in metrics_raw.items():
             metrics_dict[metric_key] = MetricQuery.from_dict(metric_dict)
-
-        res.metrics = metrics_dict
 
         return res
 
@@ -169,3 +166,5 @@ def extend_report_with_query_file(
                 summary.values.append(MetricValue(value=result, attributes=attrs))
 
         test_run.metrics = metrics
+        test_run.metadata = prof.metadata
+

--- a/stats-collector/report.py
+++ b/stats-collector/report.py
@@ -48,6 +48,7 @@ class TestRun:
     runner: Optional[str]
     spec: Dict[str, Any]
     metrics: List[MetricSummary]
+    metadata: Optional[Dict[str, Any]] = None
 
     def to_dict(self):
         ret_val = {
@@ -65,6 +66,8 @@ class TestRun:
         if self.runner:
             ret_val["runner"] = self.runner
 
+        if self.metadata:
+            ret_val["_meta"] = self.metadata
         return ret_val
 
 


### PR DESCRIPTION
This PR adds metrics metadata to the reports generated by stats-collector ( JSON and YAML reports only).
The metadata is copied from the query specification ( loaded for "dynamic queries" )

The metadata generated in the report will be used by `store_workflow_report.py` (from test-factory) in a follow-up PR.
To add metadata to the measurements in the MongoDB test documents.