### PR TITLE
feat(report-store) Add metadata support for measurements 

### DIFF
--- a/report-store/app/models.py
+++ b/report-store/app/models.py
@@ -23,12 +23,6 @@ class MetadataTree(CustomEmbeddedDocument):
     internalLabels = EmbeddedDocumentListField(NameValuePair, default=[])
 
 
-class ResultsTree(CustomEmbeddedDocument):
-    measurements = DictField()
-    # Arbitrary unstructured data, in the form of key-value pairs
-    data = DictField()
-
-
 ### Document Models
 REPORT_TYPE_SDK = "sdk"
 REPORT_TYPE_REGULAR = "regular"
@@ -42,7 +36,7 @@ class BaseReport(CustomDocument):
     name = StringField(required=True, unique=True)
     metadata = EmbeddedDocumentField(MetadataTree)
     context = DictField()
-    results = EmbeddedDocumentField(ResultsTree)
+    results = DictField()
     raw = DictField()
 
     def __str__(self):

--- a/report-store/app/routes.py
+++ b/report-store/app/routes.py
@@ -11,7 +11,6 @@ from app.models import (
     Report,
     MetadataTree,
     NameValuePair,
-    ResultsTree,
     SdkReport,
     REPORT_TYPE_SDK,
 )
@@ -99,8 +98,7 @@ def store_report(ReportCls):
     ]
 
     ### Fill results
-    results_raw = content.get("results", {})
-    report.results = ResultsTree.from_dict(results_raw)
+    report.results = content.get("results", {})
 
     ### Fill context
     report.context = content.get("context")


### PR DESCRIPTION
Make results a `DictField` i.e. a free form dictionary rather than a ResultsTree.

It is difficult (not possible?) to add a `_meta` field to a mongo engine so made the results field free-form 
(to be re-discussed when reviewing mongoengine)