### PR TITLE
fix(build): Specify linux/amd64 when building docker images

### DIFF
--- a/fakerelay/push-image.sh
+++ b/fakerelay/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/fakerelay"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/helper-images/buildkit/push-image.sh
+++ b/helper-images/buildkit/push-image.sh
@@ -14,6 +14,6 @@ cd "${SCRIPT_DIR}"
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/sentry-buildkit"
 TAG=$(git rev-parse HEAD)
 
-docker build -t "${IMAGE}:${TAG}" .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push "${IMAGE}:${TAG}"

--- a/helper-images/topicctl/push-image.sh
+++ b/helper-images/topicctl/push-image.sh
@@ -14,6 +14,6 @@ cd "${SCRIPT_DIR}"
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/sentry-topicctl"
 TAG=$(git rev-parse HEAD)
 
-docker build -t "${IMAGE}:${TAG}" .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push "${IMAGE}:${TAG}"

--- a/helper-images/toxiproxy/push-image.sh
+++ b/helper-images/toxiproxy/push-image.sh
@@ -14,6 +14,6 @@ cd "${SCRIPT_DIR}"
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/sentry-toxiproxy"
 TAG=$(git rev-parse HEAD)
 
-docker build -t "${IMAGE}:${TAG}" .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push "${IMAGE}:${TAG}"

--- a/influxdb-monitor/push-image.sh
+++ b/influxdb-monitor/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/influxdb-monitor"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/ingest-metrics-generator/push-image.sh
+++ b/ingest-metrics-generator/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/ingest-metrics-generator"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/load-starter/push-image.sh
+++ b/load-starter/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/load-starter"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/report-generator/push-image.sh
+++ b/report-generator/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/report-generator"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/report-store/push-image.sh
+++ b/report-store/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/report-store"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/stats-collector/push-image.sh
+++ b/stats-collector/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/stats-collector"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/vegeta2influx/push-image.sh
+++ b/vegeta2influx/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/public/sentry-vegeta"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG

--- a/workflow-notifier/push-image.sh
+++ b/workflow-notifier/push-image.sh
@@ -14,6 +14,6 @@ cd $SCRIPT_DIR
 IMAGE="europe-west3-docker.pkg.dev/sentry-st-testing/main/workflow-notifier"
 TAG=$(git rev-parse HEAD)
 
-docker build -t $IMAGE:$TAG .
+docker buildx build --platform linux/amd64 -t $IMAGE:$TAG .
 
 docker push $IMAGE:$TAG


### PR DESCRIPTION
Explicitly specify all docker containers will be built with linux/amd64 architecture.