### PR TITLE
feat(replay): add artifact for replay settings

### DIFF
--- a/report-store/data/w1.json
+++ b/report-store/data/w1.json
@@ -1596,6 +1596,11 @@
               "path": "/tmp/ingest-metrics-generator-settings.yaml"
             },
             {
+              "globalName": "ingest_replay_recordings_generator_settings",
+              "name": "ingest-replay-recordings-generator-settings",
+              "path": "/tmp/ingest-replay-recordings-generator-settings.yaml"
+            },
+            {
               "globalName": "test-factory-src",
               "name": "test-factory-src",
               "path": "/root/test-factory"

--- a/report-store/data/w2.json
+++ b/report-store/data/w2.json
@@ -1581,6 +1581,11 @@
               "path": "/tmp/ingest-metrics-generator-settings.yaml"
             },
             {
+              "globalName": "ingest_replay_recordings_generator_settings",
+              "name": "ingest-replay-recordings-generator-settings",
+              "path": "/tmp/ingest-replay-recordings-generator-settings.yaml"
+            },
+            {
               "globalName": "test-factory-src",
               "name": "test-factory-src",
               "path": "/root/test-factory"


### PR DESCRIPTION
When submitting a replay recording test from my branch in `test-factory` I was getting `Unsuccessful HTTP response: templates.main.tasks.run-ingest-replay-recordings-generator failed to resolve {{workflow.outputs.artifacts.ingest_replay_recordings_generator_settings}}`. 

After doing some digging it seems the artifact was missing here, not sure if that's all I'm missing for this. 