### PR TITLE
fix(Metrics): Fix --extra-tags-values param

### DIFF
--- a/ingest-metrics-generator/main.py
+++ b/ingest-metrics-generator/main.py
@@ -75,7 +75,6 @@ from readme_generator import generate_readme
 @click.option(
     "--extra-tags-values",
     type=int,
-    default=10,
     help="Number of additional tag values to generate. If --extra-tags-unique-rate is provided, this parameter defines the number of fallback (non-unique) tag values.",
 )
 @click.option(


### PR DESCRIPTION
### Overview

We set a default value for --extra-tags-values [here](https://github.com/getsentry/test-factory-utils/blob/main/ingest-metrics-generator/main.py#L78) so it is never `None`. This default value will always override the settings supplied by the settings yaml file [here](https://github.com/getsentry/test-factory-utils/blob/main/ingest-metrics-generator/main.py#L252-L253).


### Local tests

`settings.yaml`

```yaml
...
num_extra_tags: 10
extra_tags_values: 1
...
```

Before
```console
python ../test-factory-utils/ingest-metrics-generator/main.py --settings-file ../test-factory/config/ingest-metrics-generator/settings.yaml --num-messages 10
Settings:
{...'extra_tags_values': 10,...}
Sending data...
Done!
```
```console
python ../test-factory-utils/ingest-metrics-generator/main.py --settings-file ../test-factory/config/ingest-metrics-generator/settings.yaml --num-messages 10
Settings:
{...'extra_tags_values': 1...}
Sending data...
Done!
```